### PR TITLE
Improved state/preset persistence in VST3

### DIFF
--- a/IPlugExamples/MoreExamples/IPlugChunks/IPlugChunks.cpp
+++ b/IPlugExamples/MoreExamples/IPlugChunks/IPlugChunks.cpp
@@ -5,13 +5,35 @@
 #include <math.h>
 
 // The number of presets/programs
-const int kNumPrograms = 8;
+const int kNumPrograms = 128;
 
 // An enumerated list for all the parameters of the plugin
 enum EParams
 {
   kGain = 0,
   kNumParams, // the last element is used to store the total number of parameters
+};
+
+// Pointer to parameter names for use by preset file menu to dump/ append preset source from named parameters.
+const char* pParamNames[] =
+{
+  //"kParam1",
+  //"kParam2",
+  //"Param3",
+  "kGain"
+};
+
+//Pointer to SubMenu names for use by PresetSubMenu control. 8 submenus max.
+const char* pSubMenuNames[] =
+{
+  "Factory Presets 1",
+  "Factory Presets 2",
+  "User Presets 1",
+  "User Presets 2",
+  "User Presets 3",
+  "User Presets 4",
+  "User Presets 5",
+  "User Presets 6"
 };
 
 const int kDummyParamForMultislider = -2;
@@ -22,7 +44,7 @@ enum ELayout
   kH = 300
 };
 
-class ITempPresetSaveButtonControl : public IPanelControl
+/*class ITempPresetSaveButtonControl : public IPanelControl
 {
 public:
   ITempPresetSaveButtonControl(IPlugBase *pPlug, IRECT pR)
@@ -40,7 +62,7 @@ public:
     mPlug->DumpPresetBlob(presetFilePath.Get());
   }
 
-};
+};*/
 
 class PresetFunctionsMenu : public IPanelControl
 {
@@ -134,18 +156,15 @@ IPlugChunks::IPlugChunks(IPlugInstanceInfo instanceInfo)
   // Define parameter ranges, display units, labels.
   //arguments are: name, defaultVal, minVal, maxVal, step, label
   GetParam(kGain)->InitDouble("Gain", 0.0, -70.0, 12.0, 0.1, "dB");
-
-  MakePresetFromBlob("Ramp Up", "AAAAAJqZqT8AAAAAmpm5PwAAAIA9Csc/AAAAAAAA0D8AAABA4XrUPwAAAIDC9dg/AAAAwMzM3D8AAAAQ16PgPwAAALBH4eI/AAAA0MzM5D8AAADwUbjmPwAAAAjXo+g/AAAAKFyP6j8AAADMzMzsPwAAAOxRuO4/AAAAAAAA8D8AAAAAAAC8Pg==", 136);
-  MakePresetFromBlob("Ramp Down", "AAAA7FG47j8AAABI4XrsPwAAALBH4eo/AAAAGK5H6T8AAABwPQrnPwAAANDMzOQ/AAAAwB6F4z8AAAAghevhPwAAAAB7FN4/AAAAgOtR2D8AAABAuB7VPwAAAACuR9E/AAAAgEfhyj8AAAAAhevBPwAAAABSuK4/AAAAAOB6hD8AAAAAAAC8Pg==", 136);
-  MakePresetFromBlob("Triangle", "AAAAAIXrwT8AAACAR+HKPwAAAEBcj9I/AAAAgBSu1z8AAADA9SjcPwAAABDXo+A/AAAAsEfh4j8AAABQuB7lPwAAAGBmZuY/AAAAMDMz4z8AAAAAAADgPwAAAMD1KNw/AAAAQI/C1T8AAAAArkfRPwAAAICPwsU/AAAAAJqZuT8AAAAAAAAAAA==", 136);
-  MakePresetFromBlob("Inv Triangle", "AAAAAAAA8D8AAABQuB7tPwAAAKBwPeo/AAAAcD0K5z8AAABA4XrkPwAAAJDC9eA/AAAAwEfh2j8AAABAj8LVPwAAAECPwtU/AAAAwMzM3D8AAAAghevhPwAAANDMzOQ/AAAAgBSu5z8AAACYmZnpPwAAAFyPwu0/AAAAAAAA8D8AAAAAAAAAAA==", 136);
-  MakePresetFromBlob("Da Endz", "AAAAAAAA8D8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAAAA8D8AAAAAAAAAAA==", 136);
-  MakePresetFromBlob("Alternate", "AAAAAAAA8D8AAAAA4HqEPwAAAAAAAPA/AAAAAOB6hD8AAAAAAADwPwAAAADgeoQ/AAAAAAAA8D8AAAAA4HqEPwAAAAAAAPA/AAAAAOB6hD8AAAAAAADwPwAAAADgeoQ/AAAAAAAA8D8AAAAA4HqEPwAAAAAAAPA/AAAAAOB6hD8AAAAAAAAAAA==", 136);
-  MakePresetFromBlob("Alt Ramp Down", "AAAAAAAA8D8AAAAA4HqEPwAAALgehes/AAAAAOB6hD8AAACI61HoPwAAAADgeoQ/AAAAQArX4z8AAAAA4HqEPwAAAAAAAOA/AAAAAOB6hD8AAABAuB7VPwAAAADgeoQ/AAAAAKRwzT8AAAAA4HqEPwAAAAAzM8M/AAAAAOB6hD8AAAAAAAAAAA==", 136);
-  MakePresetFromBlob("Alt Ramp Up", "AAAAgJmZyT8AAAAA4HqEPwAAAIBmZtY/AAAAAOB6hD8AAAAAKVzfPwAAAADgeoQ/AAAAMFyP4j8AAAAA4HqEPwAAAEDheuQ/AAAAAOB6hD8AAADwKFznPwAAAADgeoQ/AAAAIIXr6T8AAAAA4HqEPwAAANijcO0/AAAAAOB6hD8AAAAAAAAAAA==", 136);
-
+    
   IGraphics* pGraphics = MakeGraphics(this, kW, kH);
   pGraphics->AttachPanelBackground(&COLOR_BLUE);
+
+  IText textProps3 = IText(14, &IColor(255, 0, 255, 255), "Tahoma", IText::kStyleNormal,
+    IText::kAlignNear, 0, IText::kQualityDefault, &COLOR_TRANSPARENT, &IColor(255, 0, 255, 255));
+
+  pGraphics->AttachControl(new PresetSubMenu(this, IRECT(32, 150, 208, 166), &textProps3, pSubMenuNames, &COLOR_BLACK));
+  pGraphics->AttachControl(new PresetFileMenuDev(this, IRECT(300, 250, 320, 270), pParamNames, &COLOR_BLACK, &COLOR_WHITE));
 
   mMSlider = new MultiSliderControlV(this, IRECT(10, 10, 170, 110), kDummyParamForMultislider, NUM_SLIDERS, 10, &COLOR_WHITE, &COLOR_BLACK, &COLOR_RED);
 
@@ -156,6 +175,9 @@ IPlugChunks::IPlugChunks(IPlugInstanceInfo instanceInfo)
   pGraphics->AttachControl(new PresetFunctionsMenu(this, IRECT(350, 250, 390, 290)));
 
   AttachGraphics(pGraphics);
+
+  //Initialize Presets
+  CreatePresets();
   
   // call RestorePreset(0) here which will initialize the multislider in the gui and the mSteps array
   RestorePreset(0);
@@ -233,6 +255,35 @@ void IPlugChunks::OnParamChange(int paramIdx)
       break;
     default:
       break;
+  }
+}
+
+void IPlugChunks::CreatePresets()
+{
+  IMutexLock lock(this);
+  int n = 0;
+  //Add presets below here and increment n after each preset **********
+  MakePresetFromBlob("Ramp Up", "AAAAAJqZqT8AAAAAmpm5PwAAAIA9Csc/AAAAAAAA0D8AAABA4XrUPwAAAIDC9dg/AAAAwMzM3D8AAAAQ16PgPwAAALBH4eI/AAAA0MzM5D8AAADwUbjmPwAAAAjXo+g/AAAAKFyP6j8AAADMzMzsPwAAAOxRuO4/AAAAAAAA8D8AAAAAAAC8Pg==", 136);
+  ++n;
+  MakePresetFromBlob("Ramp Down", "AAAA7FG47j8AAABI4XrsPwAAALBH4eo/AAAAGK5H6T8AAABwPQrnPwAAANDMzOQ/AAAAwB6F4z8AAAAghevhPwAAAAB7FN4/AAAAgOtR2D8AAABAuB7VPwAAAACuR9E/AAAAgEfhyj8AAAAAhevBPwAAAABSuK4/AAAAAOB6hD8AAAAAAAC8Pg==", 136);
+  ++n;
+  MakePresetFromBlob("Triangle", "AAAAAIXrwT8AAACAR+HKPwAAAEBcj9I/AAAAgBSu1z8AAADA9SjcPwAAABDXo+A/AAAAsEfh4j8AAABQuB7lPwAAAGBmZuY/AAAAMDMz4z8AAAAAAADgPwAAAMD1KNw/AAAAQI/C1T8AAAAArkfRPwAAAICPwsU/AAAAAJqZuT8AAAAAAAAAAA==", 136);
+  ++n;
+  MakePresetFromBlob("Inv Triangle", "AAAAAAAA8D8AAABQuB7tPwAAAKBwPeo/AAAAcD0K5z8AAABA4XrkPwAAAJDC9eA/AAAAwEfh2j8AAABAj8LVPwAAAECPwtU/AAAAwMzM3D8AAAAghevhPwAAANDMzOQ/AAAAgBSu5z8AAACYmZnpPwAAAFyPwu0/AAAAAAAA8D8AAAAAAAAAAA==", 136);
+  ++n;
+  MakePresetFromBlob("Da Endz", "AAAAAAAA8D8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAOB6hD8AAAAA4HqEPwAAAADgeoQ/AAAAAAAA8D8AAAAAAAAAAA==", 136);
+  ++n;
+  MakePresetFromBlob("Alternate", "AAAAAAAA8D8AAAAA4HqEPwAAAAAAAPA/AAAAAOB6hD8AAAAAAADwPwAAAADgeoQ/AAAAAAAA8D8AAAAA4HqEPwAAAAAAAPA/AAAAAOB6hD8AAAAAAADwPwAAAADgeoQ/AAAAAAAA8D8AAAAA4HqEPwAAAAAAAPA/AAAAAOB6hD8AAAAAAAAAAA==", 136);
+  ++n;
+  MakePresetFromBlob("Alt Ramp Down", "AAAAAAAA8D8AAAAA4HqEPwAAALgehes/AAAAAOB6hD8AAACI61HoPwAAAADgeoQ/AAAAQArX4z8AAAAA4HqEPwAAAAAAAOA/AAAAAOB6hD8AAABAuB7VPwAAAADgeoQ/AAAAAKRwzT8AAAAA4HqEPwAAAAAzM8M/AAAAAOB6hD8AAAAAAAAAAA==", 136);
+  ++n;
+  MakePresetFromBlob("Alt Ramp Up", "AAAAgJmZyT8AAAAA4HqEPwAAAIBmZtY/AAAAAOB6hD8AAAAAKVzfPwAAAADgeoQ/AAAAMFyP4j8AAAAA4HqEPwAAAEDheuQ/AAAAAOB6hD8AAADwKFznPwAAAADgeoQ/AAAAIIXr6T8AAAAA4HqEPwAAANijcO0/AAAAAOB6hD8AAAAAAAAAAA==", 136);
+  ++n;
+  // Add presets above here ***************
+  for (int i = 0; i < kNumPrograms - n; ++i)
+  {
+    //Add "User Preset" with default parameter settings here
+    MakePresetFromBlob("User Preset", "AAAAAJqZqT8AAAAAmpm5PwAAAIA9Csc/AAAAAAAA0D8AAABA4XrUPwAAAIDC9dg/AAAAwMzM3D8AAAAQ16PgPwAAALBH4eI/AAAA0MzM5D8AAADwUbjmPwAAAAjXo+g/AAAAKFyP6j8AAADMzMzsPwAAAOxRuO4/AAAAAAAA8D8AAAAAAAC8Pg==", 136);
   }
 }
 

--- a/IPlugExamples/MoreExamples/IPlugChunks/IPlugChunks.h
+++ b/IPlugExamples/MoreExamples/IPlugChunks/IPlugChunks.h
@@ -42,6 +42,8 @@ public:
   void PresetsChangedByHost();
 
 private:
+  //Presets
+  void CreatePresets();
 
   double mSteps[NUM_SLIDERS];
 

--- a/IPlugExamples/MoreExamples/IPlugChunks/IPlugChunks_controls.h
+++ b/IPlugExamples/MoreExamples/IPlugChunks/IPlugChunks_controls.h
@@ -222,4 +222,299 @@ private:
   int mHandleWidth;
 };
 
+/*For making presets during development- Creates a Rectangle with a triangle on it that opens a menu
+to load or save presets and banks. Also, there are options to move forward and back through presets and
+to dump preset source code to a text file. pParameterNames is a pointer to an array holding the parameter names. */
+class PresetFileMenuDev : public IPanelControl
+{
+public:
+  PresetFileMenuDev(IPlugBase *pPlug, IRECT pR, const char** pParameterNames, const IColor* pRectBgColor = &COLOR_WHITE, const IColor* pTriBgColor = &COLOR_GRAY)
+    : IPanelControl(pPlug, pR, &COLOR_BLUE)
+    , mParamNames(pParameterNames)
+    , mRectColor(*pRectBgColor)
+    , mTriColor(*pTriBgColor)
+  {}
+
+  ~PresetFileMenuDev() {}
+
+  bool Draw(IGraphics* pGraphics)
+  {
+    pGraphics->FillIRect(&mRectColor, &mRECT);
+
+    int ax = mRECT.R - 8;
+    int ay = mRECT.T + 4;
+    int bx = ax + 4;
+    int by = ay;
+    int cx = ax + 2;
+    int cy = ay + 2;
+
+    pGraphics->FillTriangle(&mTriColor, ax, ay, bx, by, cx, cy, &mBlend);
+
+    return true;
+  }
+
+  void OnMouseDown(int x, int y, IMouseMod* pMod)
+  {
+    if (pMod->L)
+    {
+      doPopupMenu();
+    }
+
+    Redraw(); // seems to need this
+    SetDirty();
+  }
+
+  void doPopupMenu()
+  {
+    IPopupMenu menu;
+
+    IGraphics* gui = mPlug->GetGUI();
+
+    menu.AddItem("Previous preset");
+    menu.AddItem("Next preset");
+    menu.AddSeparator();
+    menu.AddItem("Save Program...");
+    menu.AddItem("Save Bank...");
+    menu.AddSeparator();
+    menu.AddItem("Load Program...");
+    menu.AddItem("Load Bank...");
+    menu.AddSeparator();
+    menu.AddItem("Dump MakePresetFromNamedParams");
+    menu.AddItem("Dump MakePreset");
+    menu.AddItem("Dump MakePresetBlob");
+    menu.AddItem("DumpBankBlob");
+
+    if (gui->CreateIPopupMenu(&menu, &mRECT))
+    {
+      int itemChosen = menu.GetChosenItemIdx();
+      WDL_String fileName;
+      int numpresets = mPlug->NPresets();
+      int currpreset = mPlug->GetCurrentPresetIdx();
+      int prevpreset = (currpreset == 0) ? numpresets - 1 : currpreset - 1;
+      int nextpreset = (currpreset == numpresets - 1) ? 0 : currpreset + 1;
+
+      switch (itemChosen)
+      {
+      case 0://Previous preset
+        mPlug->RestorePreset(prevpreset);
+        mPlug->InformHostOfProgramChange();
+        mPlug->DirtyParameters();
+        break;
+      case 1://Next preset
+        mPlug->RestorePreset(nextpreset);
+        mPlug->InformHostOfProgramChange();
+        mPlug->DirtyParameters();
+        break;
+      case 3: //Save Program
+        fileName.Set(mPlug->GetPresetName(currpreset));
+        GetGUI()->PromptForFile(&fileName, kFileSave, &mPreviousPath, "fxp");
+        mPlug->SaveProgramAsFXP(&fileName);
+        break;
+      case 4: //Save Bank
+        fileName.Set("IPlugChunksBank");
+        GetGUI()->PromptForFile(&fileName, kFileSave, &mPreviousPath, "fxb");
+        mPlug->SaveBankAsFXB(&fileName);
+        break;
+      case 6: //Load Preset
+        GetGUI()->PromptForFile(&fileName, kFileOpen, &mPreviousPath, "fxp");
+        mPlug->LoadProgramFromFXP(&fileName);
+        break;
+      case 7: // Load Bank
+        GetGUI()->PromptForFile(&fileName, kFileOpen, &mPreviousPath, "fxb");
+        mPlug->LoadBankFromFXB(&fileName);
+        break;
+      case 9: //Dumps/adds MakePresetFromNamedParams to file
+        fileName.Set("presets");
+        GetGUI()->PromptForFile(&fileName, kFileSave, &mPreviousPath, "txt");
+        mPlug->AppendPrstSrcNamed(fileName.Get(), mParamNames);
+        break;
+      case 10: //Dumps/adds MakePreset to file
+        fileName.Set("presets");
+        GetGUI()->PromptForFile(&fileName, kFileSave, &mPreviousPath, "txt");
+        mPlug->AppendPrstSrc(fileName.Get());
+        break;
+      case 11: //Dumps/adds MakePresetFromBlob to file
+        fileName.Set("blobpresets");
+        GetGUI()->PromptForFile(&fileName, kFileSave, &mPreviousPath, "txt");
+        mPlug->AppendPresetBlob(fileName.Get());
+        break;
+      case 12: // Dumps Bank of Blob presets to file
+        fileName.Set("blobBank");
+        GetGUI()->PromptForFile(&fileName, kFileSave, &mPreviousPath, "txt");
+        mPlug->DumpBankBlob(fileName.Get());
+      default:
+        break;
+      }
+    }
+  }
+private:
+  WDL_String mPreviousPath;
+  IColor mRectColor;
+  IColor mTriColor;
+  const char** mParamNames;
+};
+
+/*Creates a rectangle that opens a menu with submenus for selecting presets. Supports up to 128 presets
+in up to 8 submenus depending on the number of presets. pSubmenuNames is a pointer to an array of SubMenu names.*/
+class PresetSubMenu : public IControl
+{
+private:
+  WDL_String mDisp;
+  IColor mColor;
+  const char** pSubmenuNames;
+
+public:
+  PresetSubMenu(IPlugBase *pPlug, IRECT pR, IText* pText, const char** pSubmenuNames, const IColor* pRectBgColor = &COLOR_WHITE)
+    : IControl(pPlug, pR, -1)
+    , mColor(*pRectBgColor)
+    , pSubmenuNames(pSubmenuNames)
+  {
+    mTextEntryLength = MAX_PRESET_NAME_LEN - 3;
+    mText = *pText;
+  }
+
+  ~PresetSubMenu() {}
+
+  bool Draw(IGraphics* pGraphics)
+  {
+    int pNumber = mPlug->GetCurrentPresetIdx();
+    mDisp.SetFormatted(32, "%02d: %s", pNumber + 1, mPlug->GetPresetName(pNumber));
+
+    pGraphics->FillIRect(&mColor, &mRECT);
+
+    if (CSTR_NOT_EMPTY(mDisp.Get()))
+    {
+      return pGraphics->DrawIText(&mText, mDisp.Get(), &mRECT);
+    }
+
+    return true;
+  }
+
+  void OnMouseDown(int x, int y, IMouseMod* pMod)
+  {
+    if (pMod->R)
+    {
+      const char* pname = mPlug->GetPresetName(mPlug->GetCurrentPresetIdx());
+      mPlug->GetGUI()->CreateTextEntry(this, &mText, &mRECT, pname);
+    }
+    else
+    {
+      doPopupMenu();
+    }
+
+    Redraw(); // seems to need this
+    SetDirty();
+  }
+
+  void doPopupMenu()
+  {
+    IPopupMenu mMainMenu, mSubMenu1, mSubMenu2, mSubMenu3, mSubMenu4, mSubMenu5, mSubMenu6, mSubMenu7, mSubMenu8;
+    int numItems = mPlug->NPresets();
+    int nItemsInLastSubMenu = numItems % 16;//Assuming no more than 128 presets in 8 banks (16 presets max per submenu).
+    int nSubMenus = (nItemsInLastSubMenu > 0) ? (numItems / 16) + 1 : numItems / 16;
+    int currentPresetIdx = mPlug->GetCurrentPresetIdx();
+    //Add presets
+    for (int i = 0; i < numItems; i++)
+    {
+      const char* str = mPlug->GetPresetName(i);
+      if (i < 16)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu1.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu1.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+      if (i >= 16 && i < 32)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu2.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu2.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+      if (i >= 32 && i < 48)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu3.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu3.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+      if (i >= 48 && i < 64)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu4.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu4.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+      if (i >= 64 && i < 80)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu5.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu5.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+      if (i >= 80 && i < 96)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu6.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu6.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+      if (i >= 96 && i < 112)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu7.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu7.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+      if (i >= 112 && i < 128)
+      {
+        if (i == currentPresetIdx)
+          mSubMenu8.AddItem(str, -1, IPopupMenuItem::kChecked);
+        else
+          mSubMenu8.AddItem(str, -1, IPopupMenuItem::kNoFlags);
+      }
+    }
+    //Add Banks
+    if (nSubMenus > 0) mMainMenu.AddItem(pSubmenuNames[0], &mSubMenu1);//"sub menu1"
+    if (nSubMenus > 1) mMainMenu.AddItem(pSubmenuNames[1], &mSubMenu2);//"sub menu2"
+    if (nSubMenus > 2) mMainMenu.AddItem(pSubmenuNames[2], &mSubMenu3);//"sub menu3"
+    if (nSubMenus > 3) mMainMenu.AddItem(pSubmenuNames[3], &mSubMenu4);//"sub menu4"
+    if (nSubMenus > 4) mMainMenu.AddItem(pSubmenuNames[4], &mSubMenu5);//"sub menu5"
+    if (nSubMenus > 5) mMainMenu.AddItem(pSubmenuNames[5], &mSubMenu6);//"sub menu6"
+    if (nSubMenus > 6) mMainMenu.AddItem(pSubmenuNames[6], &mSubMenu7);//"sub menu7"
+    if (nSubMenus == 8) mMainMenu.AddItem(pSubmenuNames[7], &mSubMenu8);//"sub menu8"
+
+    IPopupMenu* selectedMenu = mPlug->GetGUI()->CreateIPopupMenu(&mMainMenu, &mRECT);
+    int itemChosen = currentPresetIdx;
+
+    if (selectedMenu == &mSubMenu1) itemChosen = selectedMenu->GetChosenItemIdx();
+    if (selectedMenu == &mSubMenu2) itemChosen = selectedMenu->GetChosenItemIdx() + 16;
+    if (selectedMenu == &mSubMenu3) itemChosen = selectedMenu->GetChosenItemIdx() + 32;
+    if (selectedMenu == &mSubMenu4) itemChosen = selectedMenu->GetChosenItemIdx() + 48;
+    if (selectedMenu == &mSubMenu5) itemChosen = selectedMenu->GetChosenItemIdx() + 64;
+    if (selectedMenu == &mSubMenu6) itemChosen = selectedMenu->GetChosenItemIdx() + 80;
+    if (selectedMenu == &mSubMenu7) itemChosen = selectedMenu->GetChosenItemIdx() + 96;
+    if (selectedMenu == &mSubMenu8) itemChosen = selectedMenu->GetChosenItemIdx() + 112;
+
+    if (itemChosen > -1)
+    {
+      mPlug->RestorePreset(itemChosen);
+      mPlug->InformHostOfProgramChange();
+      mPlug->DirtyParameters();
+    }
+  }
+
+  void TextFromTextEntry(const char* txt)
+  {
+    WDL_String safeName;
+    safeName.Set(txt, MAX_PRESET_NAME_LEN);
+
+    mPlug->ModifyCurrentPreset(safeName.Get());
+    mPlug->InformHostOfProgramChange();
+    mPlug->DirtyParameters();
+    SetDirty(false);
+  }
+  bool IsDirty() { return true; }
+};
+
 #endif _IVECSLIDERS_

--- a/WDL/IPlug/IPlugBase.h
+++ b/WDL/IPlug/IPlugBase.h
@@ -254,6 +254,7 @@ protected:
   void ZeroScratchBuffers();
   
 public:
+  void ModifyPreset(int idx, const char* name = 0);  // Sets the specified preset to whatever current params are.
   void ModifyCurrentPreset(const char* name = 0);     // Sets the currently active preset to whatever current params are.
   int NPresets() { return mPresets.GetSize(); }
   int GetCurrentPresetIdx() { return mCurrentPresetIdx; }
@@ -265,8 +266,11 @@ public:
 
   // Dump the current state as source code for a call to MakePresetFromNamedParams / MakePresetFromBlob
   void DumpPresetSrcCode(const char* filename, const char* paramEnumNames[]);
+  void AppendPrstSrc(const char* filename); //See function for comments
+  void AppendPrstSrcNamed(const char* filename, const char* paramEnumNames[]); //See function for comments
   void DumpPresetBlob(const char* filename);
-  void DumpBankBlob(const char* filename);
+  void AppendPresetBlob(const char* filename); //See function for comments
+  void DumpBankBlob(const char* filename); //See function for comments
   
   virtual void PresetsChangedByHost() {} // does nothing by default
   void DirtyParameters(); // hack to tell the host to dirty file state, when a preset is recalled

--- a/WDL/IPlug/IPlugBase.h
+++ b/WDL/IPlug/IPlugBase.h
@@ -99,6 +99,7 @@ public:
   int NParams() { return mParams.GetSize(); }
   IParam* GetParam(int idx) { return mParams.Get(idx); }
   IGraphics* GetGUI() { return mGraphics; }
+  IPreset* GetPreset(int idx) { return mPresets.Get(idx); }
 
   const char* GetEffectName() { return mEffectName; }
   int GetEffectVersion(bool decimal);   // Decimal = VVVVRRMM, otherwise 0xVVVVRRMM.

--- a/WDL/IPlug/IPlugVST3.h
+++ b/WDL/IPlug/IPlugVST3.h
@@ -46,16 +46,16 @@ public:
   Steinberg::tresult PLUGIN_API setActive(Steinberg::TBool state);
   Steinberg::tresult PLUGIN_API setupProcessing (Steinberg::Vst::ProcessSetup& newSetup);
   Steinberg::tresult PLUGIN_API process(Steinberg::Vst::ProcessData& data);
-//  Steinberg::tresult PLUGIN_API setState(IBStream* state);
-//  Steinberg::tresult PLUGIN_API getState(IBStream* state);
-//  Steinberg::tresult PLUGIN_API setComponentState(IBStream *state);
+  Steinberg::tresult PLUGIN_API setState(Steinberg::IBStream* state);
+  Steinberg::tresult PLUGIN_API getState(Steinberg::IBStream* state);
+  Steinberg::tresult PLUGIN_API setComponentState(Steinberg::IBStream *state);
   Steinberg::tresult PLUGIN_API canProcessSampleSize(Steinberg::int32 symbolicSampleSize);
   Steinberg::uint32 PLUGIN_API getLatencySamples ();
   Steinberg::uint32 PLUGIN_API getTailSamples() { return GetTailSize(); }
   // IEditController
   Steinberg::IPlugView* PLUGIN_API createView (const char* name);
-  Steinberg::tresult PLUGIN_API setEditorState (Steinberg::IBStream* state);
-  Steinberg::tresult PLUGIN_API getEditorState (Steinberg::IBStream* state);
+  //Steinberg::tresult PLUGIN_API setEditorState (Steinberg::IBStream* state);
+  //Steinberg::tresult PLUGIN_API getEditorState (Steinberg::IBStream* state);
   Steinberg::tresult PLUGIN_API setParamNormalized (Steinberg::Vst::ParamID tag, Steinberg::Vst::ParamValue value);
   Steinberg::Vst::ParamValue PLUGIN_API getParamNormalized(Steinberg::Vst::ParamID tag);
   Steinberg::Vst::ParamValue PLUGIN_API plainParamToNormalized(Steinberg::Vst::ParamID tag, Steinberg::Vst::ParamValue plainValue);


### PR DESCRIPTION
Modifications that improve state/preset persistence in VST3 builds (only tested on Windows). These seem to work consistently/well with plugins using chunks but not as well when using MakePreset() or MakePresetFromNamedParams()

- .vstpreset files can be imported/exported using Reaper's plugin preset utility menu, whereas they were greyed-out before. 

- .vstpreset files created in Sonar are compatible with ones created in Reaper and vice versa. I'm not sure about FLStudio as I only have a demo that is restricted in its ability to save..... .vstpreset files load well though. Other than SaviHost, those are the only hosts I've tested.

- When kNumPrograms is greater than 1, the bank state is saved/recalled in both host project and .vstpreset files.

- fixed an issue where the plugin would crash when cancelling a "DumpPresets" operation.

- Modified IPlugChunks example project to demonstrate the improvements.